### PR TITLE
fix(herdr-btw): handle pane split response

### DIFF
--- a/pi/extensions/herdr-btw/index.ts
+++ b/pi/extensions/herdr-btw/index.ts
@@ -104,7 +104,7 @@ function parseTabCreated(stdout: string, workspaceId: string): HerdrTabCreated {
   return { kind: "tab", tabId, paneId };
 }
 
-function parsePaneCreated(stdout: string, workspaceId: string): HerdrPaneCreated {
+function parsePaneSplit(stdout: string, workspaceId: string): HerdrPaneCreated {
   let response: unknown;
   try {
     response = JSON.parse(stdout);
@@ -123,8 +123,8 @@ function parsePaneCreated(stdout: string, workspaceId: string): HerdrPaneCreated
 
   const record = result as Record<string, unknown>;
   const pane = record.pane;
-  if (record.type !== "pane_created" || !pane || typeof pane !== "object") {
-    throw new Error("response is not a pane_created result");
+  if (record.type !== "pane_info" || !pane || typeof pane !== "object") {
+    throw new Error("response is not a pane_info result");
   }
 
   const paneRecord = pane as Record<string, unknown>;
@@ -248,7 +248,7 @@ export function registerHerdrBtwExtension(
           return;
         }
         created = targetKind === "pane"
-          ? parsePaneCreated(createResult.stdout, workspaceId)
+          ? parsePaneSplit(createResult.stdout, workspaceId)
           : parseTabCreated(createResult.stdout, workspaceId);
       } catch (error) {
         report(ctx, `Cannot create Herdr BTW ${targetKind}: ${errorMessage(error)}`, "error");

--- a/pi/tests/herdr-btw.test.ts
+++ b/pi/tests/herdr-btw.test.ts
@@ -50,7 +50,7 @@ function paneSplitOutput(): string {
   return JSON.stringify({
     id: "cli:pane:split",
     result: {
-      type: "pane_created",
+      type: "pane_info",
       pane: {
         pane_id: "wH:pN",
         tab_id: "wH:tCurrent",


### PR DESCRIPTION
## Summary

- Parse the current `herdr pane split` success result as `pane_info`.
- Rename the parser to reflect that it handles a split response rather than an event.
- Update the test fixture to match the real Herdr CLI contract.

## Root cause

`pane split` returns `ResponseResult::PaneInfo`, serialized with `type: "pane_info"`. The extension expected the event-shaped `type: "pane_created"`, so it stopped after creating the pane and never ran `agent start`.

## Validation

- `node --experimental-strip-types --test tests/herdr-btw.test.ts` — 11/11 passed using the exact changed files reconstructed from this branch.
- Focused strict TypeScript compilation passed.
- Negative regression check confirmed the old parser stops after `pane split` and never starts the agent.